### PR TITLE
New feature: Add default value at the global level/plugin's settings page.

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -82,25 +82,25 @@ class quizaccess_honestycheck extends quizaccess_honestycheck_parent_class_alias
             mod_quiz_mod_form $quizform, MoodleQuickForm $mform) {
         $mform->addElement('select', 'honestycheckrequired',
                 get_string('honestycheckrequired', 'quizaccess_honestycheck'),
-                array(
+                [
                     0 => get_string('notrequired', 'quizaccess_honestycheck'),
                     1 => get_string('honestycheckrequiredoption', 'quizaccess_honestycheck'),
-                ));
-        $mform->addHelpButton('honestycheckrequired',
-                'honestycheckrequired', 'quizaccess_honestycheck');
+                ]);
+        $mform->setDefault('honestycheckrequired', get_config('quizaccess_honestycheck', 'honestycheckrequired'));
+        $mform->addHelpButton('honestycheckrequired', 'honestycheckrequired', 'quizaccess_honestycheck');
     }
 
     public static function save_settings($quiz) {
         global $DB;
-        if (empty($quiz->honestycheckrequired)) {
-            $DB->delete_records('quizaccess_honestycheck', array('quizid' => $quiz->id));
+        $record = [
+            "quizid" => $quiz->id,
+            "honestycheckrequired" => (empty($quiz->honestycheckrequired)) ? 0 : 1,
+        ];
+        if ($DB->record_exists('quizaccess_honestycheck', array('quizid' => $quiz->id))) {
+            $sql = 'UPDATE {quizaccess_honestycheck} SET honestycheckrequired = :honestycheckrequired WHERE quizid = :quizid';
+            $DB->execute($sql, $record);
         } else {
-            if (!$DB->record_exists('quizaccess_honestycheck', array('quizid' => $quiz->id))) {
-                $record = new stdClass();
-                $record->quizid = $quiz->id;
-                $record->honestycheckrequired = 1;
-                $DB->insert_record('quizaccess_honestycheck', $record);
-            }
+            $DB->insert_record('quizaccess_honestycheck', $record);
         }
     }
 

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,36 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Global configuration settings for the quizaccess_honestycheck plugin.
+ *
+ * @package   quizaccess_honestycheck
+ * @author    Sumaiya Javed <sumaiya.javed@catalyst.net.nz>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+$options = [
+    0 => new lang_string('notrequired', 'quizaccess_honestycheck'),
+    1 => new lang_string('honestycheckrequiredoption', 'quizaccess_honestycheck'),
+];
+$setting = new admin_setting_configselect('quizaccess_honestycheck/honestycheckrequired',
+    new lang_string('honestycheckrequired', 'quizaccess_honestycheck'), new lang_string('honestycheckrequired_help', 'quizaccess_honestycheck'),
+    0, $options);
+$setting->set_advanced_flag_options(admin_setting_flag::ENABLED, true);
+$setting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+$settings->add($setting);


### PR DESCRIPTION
Hi,
This will create a settings page for the plugin to save the default value of honestycheckrequired.
The new instances of a quiz will have this default value set at the time of creation.

Regards,
Sumaiya
